### PR TITLE
Add Jest setup and tests for useLocalStorage hook

### DIFF
--- a/portfolio-algoritmos/jest.config.ts
+++ b/portfolio-algoritmos/jest.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};
+
+export default config;

--- a/portfolio-algoritmos/jest.setup.ts
+++ b/portfolio-algoritmos/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/portfolio-algoritmos/package.json
+++ b/portfolio-algoritmos/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --no-lint",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.3.0",
@@ -23,6 +24,11 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.0",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "@types/jest": "^29",
+    "@testing-library/react": "^14",
+    "@testing-library/jest-dom": "^6"
   }
 }

--- a/portfolio-algoritmos/src/hooks/useLocalStorage.test.ts
+++ b/portfolio-algoritmos/src/hooks/useLocalStorage.test.ts
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLocalStorage } from './useLocalStorage';
+
+describe('useLocalStorage', () => {
+  const KEY = 'test-key';
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('retrieves the initial value from localStorage', () => {
+    window.localStorage.setItem(KEY, JSON.stringify('stored'));
+
+    const { result } = renderHook(() => useLocalStorage(KEY, 'default'));
+
+    expect(result.current[0]).toBe('stored');
+  });
+
+  it('updates the stored value via setValue', () => {
+    const { result } = renderHook(() => useLocalStorage(KEY, 'initial'));
+
+    act(() => {
+      result.current[1]('updated');
+    });
+
+    expect(result.current[0]).toBe('updated');
+    expect(window.localStorage.getItem(KEY)).toBe(JSON.stringify('updated'));
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest and React Testing Library in `portfolio-algoritmos`
- add Jest setup file
- add tests for `useLocalStorage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a4b31fe08331985c440f5cbe0133