### PR TITLE
Fix license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ Contribuições são bem-vindas! Sinta-se à vontade para abrir issues ou enviar
 
 ## 📄 Licença
 
-Este projeto está licenciado sob a licença MIT - veja o arquivo [LICENSE](LICENSE) para mais detalhes. 
+Este projeto está licenciado sob a [Licença MIT](LICENSE). Consulte o arquivo para mais detalhes. 


### PR DESCRIPTION
## Summary
- update README license section to ensure the link works

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a49bce10833199063193c2a84879